### PR TITLE
Clarify the ErrorCollector API regarding errKey

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -16,22 +16,22 @@ func getFirstAggregatedErr(aggregatedErrors map[string]*aggregatedError) *aggreg
 func TestCollector_addError(t *testing.T) {
 	c := NewErrorCollector()
 	err := errors.New("testing")
-	c.addError(err, SeverityError, nil)
+	c.addError(err, SeverityError, nil, "")
 
 	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
 	}
 
-	c.addError(err, SeverityError, nil)
+	c.addError(err, SeverityError, nil, "")
 	if getFirstAggregatedErr(c.aggregatedErrors).TotalCount != 2 {
 		t.Errorf("expected two elements")
 	}
 }
 
-func TestCollector_Report(t *testing.T) {
+func TestCollector_ReportError(t *testing.T) {
 	c := NewErrorCollector()
 	err := errors.New("testing")
-	c.Report(err)
+	c.ReportError(err)
 
 	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
@@ -87,7 +87,7 @@ func TestCollector_Report_errKey(t *testing.T) {
 	err := errors.New("testing")
 	errKey := "grouped-err"
 	errClass := "*errors.errorString"
-	c.Report(err, errClass+"@"+errKey)
+	c.Report(ErrorReport{err: err, errKey: errClass + "@" + errKey})
 
 	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
@@ -250,7 +250,7 @@ func TestCollector_ReportErrorWithContext(t *testing.T) {
 	}
 	errorInstance := NewCustomErrorInstance("testing", "manual_error", []string{"line 0:", "error in testingError"})
 	errorWithContext := NewErrorWithContext(errorInstance, SeverityError, &httpContext)
-	c.ReportErrorWithContext(errorWithContext, SeverityError)
+	c.ReportErrorWithContext(errorWithContext, SeverityError, "")
 
 	if len(c.aggregatedErrors) != 1 {
 		t.Errorf("expected one element")
@@ -273,7 +273,7 @@ func TestCollector_ReportErrorWithContext(t *testing.T) {
 func TestCollector_getAggregatedErrors(t *testing.T) {
 	c := NewErrorCollector()
 	err := errors.New("testing")
-	c.addError(err, SeverityError, nil)
+	c.addError(err, SeverityError, nil, "")
 
 	aggregatedErr := getFirstAggregatedErr(c.aggregatedErrors)
 	payload := c.getAggregatedErrors()

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -109,7 +109,7 @@ func TestExporter_Export(t *testing.T) {
 func TestExporter_Push(t *testing.T) {
 	c := NewErrorCollector()
 	errTest := errors.New("testing")
-	c.Report(errTest)
+	c.ReportError(errTest)
 	e := NewErrorExporter(&c)
 	err := e.PushToGateway("http://localhost:7878")
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -23,7 +23,7 @@ func parseJSON(exportedErrors string) payload {
 func TestHandler(t *testing.T) {
 	body := "some body"
 	c := NewErrorCollector()
-	c.Report(errFunc())
+	c.ReportError(errFunc())
 	c.ReportWithHTTPContext(errFunc(), &HTTPContext{
 		RequestMethod:  "GET",
 		RequestURL:     "http://example.com",
@@ -62,7 +62,7 @@ func TestConcurrency(t *testing.T) {
 			defer wg.Done()
 
 			for i := 0; i < maxIterations; i++ {
-				c.Report(errFunc())
+				c.ReportError(errFunc())
 			}
 		}()
 		e.Export()


### PR DESCRIPTION
This is a followup to [this discussion](https://github.com/periskop-dev/periskop-go/pull/6#discussion_r860811927). 

In this PR I've made some changes to the `ErrorCollector` interface, in order to clarify how `errKey` is expected to be used. 

Before this change, one would be able to pass in more than a single `errKey` value, while in fact only the first value in the slice would ever be used in order to determine the aggregation key. With this change, it is clear that `errKey` is a single value.

While working on this, I had to make some changes to some function signatures. I did my best to preserve what I could, but this is certainly a breaking change for those who are already passing in `errKey` through any of the `Report*()` functions, and for those who use `Report(err)` and relying on the default `SeverityError`.

The new interface of `ErrorCollector` after this change is:

| Before | After |
| :-- | :-- |
| `Report(err error)` | `Report(report ErrorReport)` |
| | `ReportError(err error)` |
| `ReportWithSeverity(err error, severity Severity, errKey ...string)` | `ReportWithSeverity(err error, severity Severity)` |
| `ReportWithHTTPContext(err error, httpCtx *HTTPContext, errKey ...string)` | `ReportWithHTTPContext(err error, httpCtx *HTTPContext)` |
| `ReportWithHTTPContextAndSeverity(err error, severity Severity, httpCtx *HTTPContext, errKey ...string)` | `ReportWithHTTPContextAndSeverity(err error, severity Severity, httpCtx *HTTPContext)` |
| `ReportWithHTTPRequest(err error, r *http.Request, errKey ...string)` | `ReportWithHTTPRequest(err error, r *http.Request)` |
| `ReportWithHTTPRequestAndSeverity(err error, severity Severity, r *http.Request, errKey ...string)` | `ReportWithHTTPRequestAndSeverity(err error, severity Severity, r *http.Request)` |
| `ReportErrorWithContext(errWithContext ErrorWithContext, severity Severity, errKey ...string)` | `ReportErrorWithContext(errWithContext ErrorWithContext, severity Severity, errKey string)` |
